### PR TITLE
Add bintray profile to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2287,5 +2287,31 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>bintray</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>bintray</id>
+                    <name>bintray</name>
+                    <url>https://jcenter.bintray.com</url>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>bintray</id>
+                    <name>bintray-plugins</name>
+                    <url>https://jcenter.bintray.com</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Added bintray profile to the parent pom so that developers do not need to change their settings.xml to build killbill, also could make build automation easier.  Tested this out and it seems to work the same as adding bintray to the settings.xml, hopefully it will not affect your process for publishing killbill artifacts.  Let me know if you see any issues!  