### PR TITLE
Support for JDK 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,9 @@ updates:
     - dependency-name: org.glassfish.hk2:*
       versions:
         - ">= 3.0.0"
+    - dependency-name: org.glassfish.jaxb:jaxb-runtime
+      versions:
+        - ">= 3.0.0"
     - dependency-name: org.glassfish.jersey.*:*
       versions:
         - ">= 3.0.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
     - dependency-name: com.izettle:dropwizard-metrics-influxdb
       versions:
         - "> 1.2.1-rc1"
+    # 207 requires Java 11
+    - dependency-name: io.airlift:concurrent
+      versions:
+        - ">= 207"
+    # 207 requires Java 11
+    - dependency-name: io.airlift:log
+      versions:
+        - ">= 207"
     # https://github.com/brettwooldridge/HikariCP/issues/335
     - dependency-name: io.dropwizard.metrics:*
       versions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   - pull_request
   - push
+  - workflow_dispatch
 
 env:
   MAVEN_FLAGS: "-B -ff -Dcheck.skip-spotbugs=true -DskipTests=true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   - pull_request
+  - push
 
 env:
   MAVEN_FLAGS: "-B -ff -Dcheck.skip-spotbugs=true -DskipTests=true"

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,20 @@
+0.144.53
+    Add com.sun.xml.bind:jaxb-impl 3.0.2-b01
+    Update concurrent from 202 to 206
+    Update guava from 30.1-jre to 30.1.1-jre
+    Update jackson from 2.12.3 to 2.12.4
+    Update jakarta.xml.bind-api from 2.3.3 to 3.0.1
+    Update janino from 3.1.3 to 3.1.4
+    Update jetty from 9.4.40.v20210413 to 9.4.42.v20210604
+    Update jooby from 1.6.8 to 1.6.9
+    Update log from 205 to 206
+    Update mysql-connector-java from 8.0.23 to 8.0.25
+    Update netty from 4.1.63.Final to 4.1.66.Final
+    Update slf4j from 1.7.30 to 1.7.31
+    Update snakeyaml from 1.27 to 1.29
+    Update sortpom-maven-plugin from 2.13.1 to 3.0.0
+    Add javac-release profile for JDK11+ builds
+
 0.144.52
     Update killbill-base-plugin from 4.2.11 to 4.2.12
 

--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,9 @@
 0.144.53
-    Add com.sun.xml.bind:jaxb-impl 3.0.2-b01
+    Add com.sun.activation:jakarta.activation 2.0.1
+    Add org.glassfish.jaxb:jaxb-runtime 2.3.4
     Update concurrent from 202 to 206
     Update guava from 30.1-jre to 30.1.1-jre
     Update jackson from 2.12.3 to 2.12.4
-    Update jakarta.xml.bind-api from 2.3.3 to 3.0.1
     Update janino from 3.1.3 to 3.1.4
     Update jetty from 9.4.40.v20210413 to 9.4.42.v20210604
     Update jooby from 1.6.8 to 1.6.9

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <check.skip-enforcer>false</check.skip-enforcer>
         <check.skip-rat>false</check.skip-rat>
         <check.skip-spotbugs>false</check.skip-spotbugs>
-        <check.spotbugs-exclude-filter-file />
+        <check.spotbugs-exclude-filter-file/>
         <compiler.fail-warnings>false</compiler.fail-warnings>
         <ehcache.version>3.9.3</ehcache.version>
         <guava.version>30.1-jre</guava.version>
@@ -130,8 +130,8 @@
         <osgi.activator>$${classes;EXTENDS;org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase}</osgi.activator>
         <osgi.dependency>*;scope=compile|runtime;inline=true</osgi.dependency>
         <osgi.description>${project.description}</osgi.description>
-        <osgi.export />
-        <osgi.extra-import />
+        <osgi.export/>
+        <osgi.extra-import/>
         <osgi.fixupmessages>"Classes found in the wrong directory...","Unused Import-Package instructions...","While traversing the type tree for...";is:=ignore</osgi.fixupmessages>
         <osgi.import>
             ${osgi.extra-import},
@@ -195,7 +195,7 @@
         </osgi.import>
         <osgi.name>${project.name}</osgi.name>
         <osgi.noclassforname>true</osgi.noclassforname>
-        <osgi.private />
+        <osgi.private/>
         <osgi.symbolic-name>${project.groupId}.${project.artifactId}</osgi.symbolic-name>
         <osgi.transitive-dependency>true</osgi.transitive-dependency>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -319,8 +319,8 @@
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                        <artifactId>servlet-api</artifactId>
                         <groupId>org.mortbay.jetty</groupId>
+                        <artifactId>servlet-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -336,8 +336,8 @@
                 <exclusions>
                     <!-- this empty dependency is a hack and not needed -->
                     <exclusion>
-                        <artifactId>listenablefuture</artifactId>
                         <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -377,9 +377,9 @@
                 <version>1.2.1-rc1</version>
                 <exclusions>
                     <exclusion>
-                        <artifactId>validation-api</artifactId>
                         <!-- We use jakarta.validation:jakarta.validation-api instead -->
                         <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -479,8 +479,8 @@
                 <version>${metrics.version}</version>
                 <exclusions>
                     <exclusion>
-                        <artifactId>jdbi</artifactId>
                         <groupId>org.jdbi</groupId>
+                        <artifactId>jdbi</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -569,14 +569,14 @@
                 <version>${swagger.version}</version>
                 <exclusions>
                     <exclusion>
-                        <artifactId>jsr311-api</artifactId>
                         <!-- We use jakarta.ws.rs:jakarta.ws.rs-api instead -->
                         <groupId>javax.ws.rs</groupId>
+                        <artifactId>jsr311-api</artifactId>
                     </exclusion>
                     <exclusion>
-                        <artifactId>validation-api</artifactId>
                         <!-- We use jakarta.validation:jakarta.validation-api instead -->
                         <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -591,14 +591,14 @@
                 <version>0.7.3</version>
                 <exclusions>
                     <exclusion>
-                        <artifactId>commons-logging</artifactId>
                         <!-- Use jcl-over-slf4j instead -->
                         <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
                     </exclusion>
                     <exclusion>
-                        <artifactId>slf4j-simple</artifactId>
                         <!-- Conflicts with logback in some tests -->
                         <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-simple</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -831,9 +831,9 @@
                 <version>${async-http-client.version}</version>
                 <exclusions>
                     <exclusion>
-                        <artifactId>javax.activation</artifactId>
                         <!-- Use jakarta.activation-api instead -->
                         <groupId>com.sun.activation</groupId>
+                        <artifactId>javax.activation</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -911,14 +911,14 @@
                 <version>${ehcache.version}</version>
                 <exclusions>
                     <exclusion>
-                        <artifactId>javax.activation-api</artifactId>
                         <!-- We use jakarta.activation:jakarta.activation-api instead -->
                         <groupId>javax.activation</groupId>
+                        <artifactId>javax.activation-api</artifactId>
                     </exclusion>
                     <exclusion>
-                        <artifactId>jaxb-api</artifactId>
                         <!-- We use jakarta.xml.bind:jakarta.xml.bind-api instead -->
                         <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -944,8 +944,8 @@
                 <exclusions>
                     <!-- Repackaged artifact of javax.inject for the GlassFish OSGI environment -->
                     <exclusion>
-                        <artifactId>jakarta.inject</artifactId>
                         <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -956,13 +956,13 @@
                 <exclusions>
                     <!-- Repackaged artifact of aopalliance for the GlassFish OSGI environment -->
                     <exclusion>
-                        <artifactId>aopalliance-repackaged</artifactId>
                         <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>aopalliance-repackaged</artifactId>
                     </exclusion>
                     <!-- Repackaged artifact of javax.inject for the GlassFish OSGI environment -->
                     <exclusion>
-                        <artifactId>jakarta.inject</artifactId>
                         <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -973,8 +973,8 @@
                 <exclusions>
                     <!-- Repackaged artifact of javax.inject for the GlassFish OSGI environment -->
                     <exclusion>
-                        <artifactId>jakarta.inject</artifactId>
                         <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -985,8 +985,8 @@
                 <exclusions>
                     <!-- Repackaged artifact of javax.inject for the GlassFish OSGI environment -->
                     <exclusion>
-                        <artifactId>jakarta.inject</artifactId>
                         <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -997,8 +997,8 @@
                 <exclusions>
                     <!-- Repackaged artifact of javax.inject for the GlassFish OSGI environment -->
                     <exclusion>
-                        <artifactId>jakarta.inject</artifactId>
                         <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1009,13 +1009,13 @@
                 <exclusions>
                     <!-- Repackaged artifact of aopalliance for the GlassFish OSGI environment -->
                     <exclusion>
-                        <artifactId>aopalliance-repackaged</artifactId>
                         <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>aopalliance-repackaged</artifactId>
                     </exclusion>
                     <!-- Repackaged artifact of javax.inject for the GlassFish OSGI environment -->
                     <exclusion>
-                        <artifactId>jakarta.inject</artifactId>
                         <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1076,8 +1076,8 @@
                 <version>${jooby.version}</version>
                 <exclusions>
                     <exclusion>
-                        <artifactId>logback-classic</artifactId>
                         <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1097,9 +1097,9 @@
                 <version>3.14.7</version>
                 <exclusions>
                     <exclusion>
-                        <artifactId>jaxb-api</artifactId>
                         <!-- We use jakarta.xml.bind:jakarta.xml.bind-api instead -->
                         <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1696,12 +1696,12 @@
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                        <artifactId>junit</artifactId>
                         <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
                     </exclusion>
                     <exclusion>
-                        <artifactId>guice</artifactId>
                         <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1750,18 +1750,6 @@
         </pluginRepository>
     </pluginRepositories>
     <build>
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.scm</groupId>
-                <artifactId>maven-scm-provider-gitexe</artifactId>
-                <version>1.11.2</version>
-            </extension>
-            <extension>
-                <groupId>org.apache.maven.scm</groupId>
-                <artifactId>maven-scm-manager-plexus</artifactId>
-                <version>1.11.2</version>
-            </extension>
-        </extensions>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -1778,14 +1766,6 @@
                     <groupId>com.github.ekryd.sortpom</groupId>
                     <artifactId>sortpom-maven-plugin</artifactId>
                     <version>3.0.0</version>
-                    <executions>
-                        <execution>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>sort</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <keepBlankLines>true</keepBlankLines>
@@ -1797,26 +1777,34 @@
                         <sortProperties>true</sortProperties>
                         <createBackupFile>false</createBackupFile>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>sort</goal>
+                            </goals>
+                            <phase>verify</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <version>4.2.0</version>
-                    <executions>
-                        <execution>
-                            <id>default</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <skip>${check.skip-spotbugs}</skip>
                         <jvmArgs>-Xmx${build.jvmsize}</jvmArgs>
                         <failOnError>${check.fail-spotbugs}</failOnError>
                         <excludeFilterFile>${check.spotbugs-exclude-filter-file}</excludeFilterFile>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>default</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <phase>verify</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>com.hubspot.maven.plugins</groupId>
@@ -1838,18 +1826,18 @@
                     <groupId>com.ning.maven.plugins</groupId>
                     <artifactId>maven-dependency-versions-check-plugin</artifactId>
                     <version>2.0.4</version>
-                    <executions>
-                        <execution>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <skip>${check.skip-dependency-versions}</skip>
                         <failBuildInCaseOfConflict>${check.fail-dependency-versions}</failBuildInCaseOfConflict>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <phase>verify</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>
@@ -1861,14 +1849,6 @@
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>4.2.1</version>
                     <extensions>true</extensions>
-                    <dependencies>
-                        <dependency>
-                            <!-- Need a more recent version to turn off scanning for Class.forName usage -->
-                            <groupId>biz.aQute.bnd</groupId>
-                            <artifactId>biz.aQute.bndlib</artifactId>
-                            <version>5.3.0</version>
-                        </dependency>
-                    </dependencies>
                     <configuration>
                         <instructions>
                             <Bundle-Name>${osgi.name}</Bundle-Name>
@@ -1884,6 +1864,14 @@
                             <_fixupmessages>${osgi.fixupmessages}</_fixupmessages>
                         </instructions>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <!-- Need a more recent version to turn off scanning for Class.forName usage -->
+                            <groupId>biz.aQute.bnd</groupId>
+                            <artifactId>biz.aQute.bndlib</artifactId>
+                            <version>5.3.0</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1933,16 +1921,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.2</version>
-                    <executions>
-                        <execution>
-                            <id>default</id>
-                            <phase>process-test-classes</phase>
-                            <goals>
-                                <goal>analyze-only</goal>
-                                <goal>analyze-duplicate</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <skip>${check.skip-dependency}</skip>
                         <failOnWarning>${check.fail-dependency}</failOnWarning>
@@ -1952,6 +1930,16 @@
                             <ignoredUnusedDeclaredDependency>org.apache.felix:org.apache.felix.framework</ignoredUnusedDeclaredDependency>
                         </ignoredUnusedDeclaredDependencies>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>default</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                                <goal>analyze-duplicate</goal>
+                            </goals>
+                            <phase>process-test-classes</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1966,22 +1954,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.0.0-M3</version>
-                    <executions>
-                        <execution>
-                            <id>default</id>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>enforce</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>extra-enforcer-rules</artifactId>
-                            <version>1.3</version>
-                        </dependency>
-                    </dependencies>
                     <configuration>
                         <skip>${check.skip-enforcer}</skip>
                         <fail>${check.fail-enforcer}</fail>
@@ -2015,8 +1987,8 @@
                                     <include>junit:junit:[4.11,)</include>
                                 </includes>
                             </bannedDependencies>
-                            <banDuplicatePomDependencyVersions />
-                            <requireUpperBoundDeps />
+                            <banDuplicatePomDependencyVersions/>
+                            <requireUpperBoundDeps/>
                             <requireMavenVersion>
                                 <version>3.3.9</version>
                             </requireMavenVersion>
@@ -2028,6 +2000,22 @@
                             </enforceBytecodeVersion>
                         </rules>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>extra-enforcer-rules</artifactId>
+                            <version>1.3</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id>default</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <phase>validate</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -2036,10 +2024,10 @@
                     <executions>
                         <execution>
                             <id>sign-artifacts</id>
-                            <phase>verify</phase>
                             <goals>
                                 <goal>sign</goal>
                             </goals>
+                            <phase>verify</phase>
                             <configuration>
                                 <!-- Prevent `gpg` from using pinentry programs -->
                                 <gpgArguments>
@@ -2059,23 +2047,30 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
-                    <executions>
-                        <execution>
-                            <id>attach-tests</id>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>test-jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <skipIfEmpty>true</skipIfEmpty>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-tests</id>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                            <phase>package</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.2.0</version>
+                    <configuration>
+                        <quiet>true</quiet>
+                        <source>${project.build.targetJdk}</source>
+                        <encoding>${project.build.sourceEncoding}</encoding>
+                        <maxmemory>${build.jvmsize}</maxmemory>
+                        <additionalOptions>-Xdoclint:none</additionalOptions>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>
@@ -2084,13 +2079,6 @@
                             </goals>
                         </execution>
                     </executions>
-                    <configuration>
-                        <quiet>true</quiet>
-                        <source>${project.build.targetJdk}</source>
-                        <encoding>${project.build.sourceEncoding}</encoding>
-                        <maxmemory>${build.jvmsize}</maxmemory>
-                        <additionalOptions>-Xdoclint:none</additionalOptions>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -2141,11 +2129,11 @@
                     <executions>
                         <execution>
                             <id>attach-sources</id>
-                            <phase>package</phase>
                             <goals>
                                 <goal>jar-no-fork</goal>
                                 <goal>test-jar-no-fork</goal>
                             </goals>
+                            <phase>package</phase>
                         </execution>
                     </executions>
                 </plugin>
@@ -2181,16 +2169,16 @@
                     <version>0.13</version>
                     <executions>
                         <execution>
-                            <phase>verify</phase>
                             <goals>
                                 <goal>check</goal>
                             </goals>
+                            <phase>verify</phase>
                             <configuration>
                                 <skip>${check.skip-rat}</skip>
                                 <ignoreErrors>${check.ignore-rat}</ignoreErrors>
                                 <licenseFamilies>
-                                    <licenseFamily implementation="org.apache.rat.license.Apache20LicenseFamily" />
-                                    <licenseFamily implementation="org.apache.rat.license.MITLicenseFamily" />
+                                    <licenseFamily implementation="org.apache.rat.license.Apache20LicenseFamily"/>
+                                    <licenseFamily implementation="org.apache.rat.license.MITLicenseFamily"/>
                                 </licenseFamilies>
                                 <useDefaultExcludes>true</useDefaultExcludes>
                                 <parseSCMIgnoresAsExcludes>true</parseSCMIgnoresAsExcludes>
@@ -2243,15 +2231,6 @@
                     <groupId>org.basepom.maven</groupId>
                     <artifactId>duplicate-finder-maven-plugin</artifactId>
                     <version>1.5.0</version>
-                    <executions>
-                        <execution>
-                            <id>default</id>
-                            <phase>process-test-classes</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <skip>${check.skip-duplicate-finder}</skip>
                         <failBuildInCaseOfConflict>${check.fail-duplicate-finder}</failBuildInCaseOfConflict>
@@ -2327,6 +2306,15 @@
                             <ignoredResourcePattern>THIRD-PARTY</ignoredResourcePattern>
                         </ignoredResourcePatterns>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>default</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <phase>process-test-classes</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -2445,6 +2433,18 @@
                 <artifactId>duplicate-finder-maven-plugin</artifactId>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.scm</groupId>
+                <artifactId>maven-scm-provider-gitexe</artifactId>
+                <version>1.11.2</version>
+            </extension>
+            <extension>
+                <groupId>org.apache.maven.scm</groupId>
+                <artifactId>maven-scm-manager-plexus</artifactId>
+                <version>1.11.2</version>
+            </extension>
+        </extensions>
     </build>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1921,6 +1921,8 @@
                         <compilerArgs>
                             <!-- Configure manifold plugin -->
                             <arg>-Xplugin:Manifold</arg>
+                            <!-- Allow access to internal packages -->
+                            <arg>-XDignore.symbol.file</arg>
                         </compilerArgs>
                         <!-- Add the processor path for the plugin -->
                         <annotationProcessorPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 <!--
   ~ Copyright 2010-2014 Ning, Inc.
   ~ Copyright 2014-2020 Groupon, Inc
-  ~ Copyright 2020-2020 Equinix, Inc
-  ~ Copyright 2014-2020 The Billing Project, LLC
+  ~ Copyright 2020-2021 Equinix, Inc
+  ~ Copyright 2014-2021 The Billing Project, LLC
   ~
   ~ The Billing Project licenses this file to you under the Apache License, version 2.0
   ~ (the "License"); you may not use this file except in compliance with the
@@ -426,12 +426,12 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>concurrent</artifactId>
-                <version>202</version>
+                <version>208</version>
             </dependency>
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>log</artifactId>
-                <version>205</version>
+                <version>208</version>
             </dependency>
             <dependency>
                 <groupId>io.airlift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -405,9 +405,9 @@
                 <version>1.15</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>3.0.2-b01</version>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>2.0.1</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe</groupId>
@@ -623,7 +623,7 @@
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>3.0.1</version>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>javax.cache</groupId>
@@ -917,18 +917,6 @@
                 <groupId>org.ehcache</groupId>
                 <artifactId>ehcache</artifactId>
                 <version>${ehcache.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <!-- We use jakarta.activation:jakarta.activation-api instead -->
-                        <groupId>javax.activation</groupId>
-                        <artifactId>javax.activation-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <!-- We use jakarta.xml.bind:jakarta.xml.bind-api instead -->
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.ehcache</groupId>
@@ -973,6 +961,11 @@
                         <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>2.3.4</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@
         <repository.snapshot.url>https://oss.sonatype.org/content/repositories/snapshots/</repository.snapshot.url>
         <skipTests>false</skipTests>
         <slf4j.version>1.7.30</slf4j.version>
+        <surefireArgLine>-Xmx${build.jvmsize} -XX:MaxDirectMemorySize=512m</surefireArgLine>
         <swagger.version>1.6.2</swagger.version>
     </properties>
     <dependencyManagement>
@@ -2148,7 +2149,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M5</version>
                     <configuration>
-                        <argLine>-Xmx${build.jvmsize} -XX:MaxDirectMemorySize=512m</argLine>
+                        <argLine>${surefireArgLine}</argLine>
                         <runOrder>random</runOrder>
                         <skipTests>${skipTests}</skipTests>
                         <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -2690,6 +2691,8 @@
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
+                <!-- illegal-access=permit is for cglib (jDBI) -->
+                <surefireArgLine>-Xmx${build.jvmsize} -XX:MaxDirectMemorySize=512m --illegal-access=permit</surefireArgLine>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <check.spotbugs-exclude-filter-file/>
         <compiler.fail-warnings>false</compiler.fail-warnings>
         <ehcache.version>3.9.3</ehcache.version>
-        <guava.version>30.1-jre</guava.version>
+        <guava.version>30.1.1-jre</guava.version>
         <guice.version>4.2.3</guice.version>
         <hk2.version>2.6.1</hk2.version>
         <jackson.version>2.12.3</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -431,12 +431,14 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>concurrent</artifactId>
-                <version>208</version>
+                <!-- 207 requires Java 11 -->
+                <version>206</version>
             </dependency>
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>log</artifactId>
-                <version>208</version>
+                <!-- 207 requires Java 11 -->
+                <version>206</version>
             </dependency>
             <dependency>
                 <groupId>io.airlift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1877,6 +1877,7 @@
                             <Embed-Dependency>${osgi.dependency}</Embed-Dependency>
                             <Embed-Transitive>${osgi.transitive-dependency}</Embed-Transitive>
                             <_noclassforname>${osgi.noclassforname}</_noclassforname>
+                            <_noee>true</_noee>
                             <_fixupmessages>${osgi.fixupmessages}</_fixupmessages>
                         </instructions>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1837,6 +1837,14 @@
                     <configuration>
                         <skip>${check.skip-dependency-versions}</skip>
                         <failBuildInCaseOfConflict>${check.fail-dependency-versions}</failBuildInCaseOfConflict>
+                        <resolvers>
+                            <resolver>
+                                <strategyName>single-digit</strategyName>
+                                <includes>
+                                    <include>com.google.guava:guava</include>
+                                </includes>
+                            </resolver>
+                        </resolvers>
                     </configuration>
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1899,10 +1899,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
+                        <!-- See profiles section for <release> configuration -->
                         <source>${project.build.targetJdk}</source>
                         <target>${project.build.targetJdk}</target>
-                        <!-- Since Java9 -->
-                        <!-- <release>${project.build.targetJdk}</release> -->
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <maxmem>${build.jvmsize}</maxmem>
                         <failOnWarning>${compiler.fail-warnings}</failOnWarning>
@@ -2683,6 +2682,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>javac-release</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,11 @@
                 <version>1.15</version>
             </dependency>
             <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>3.0.2-b01</version>
+            </dependency>
+            <dependency>
                 <groupId>com.typesafe</groupId>
                 <artifactId>config</artifactId>
                 <version>1.4.1</version>
@@ -615,7 +620,7 @@
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>2.3.3</version>
+                <version>3.0.1</version>
             </dependency>
             <dependency>
                 <groupId>javax.cache</groupId>


### PR DESCRIPTION
See individual commits. CI likely won't pass until Kill Bill is updated.

Note the new `javac-release` profile automatically enabled for JDK11+ builds.

/cc @andrenpaes