### PR TITLE
pom.xml: update version to 0.145.0-SNAPSHOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
         with:
           repository: killbill/killbill-oss-parent
           path: killbill-oss-parent
+      - name: Checkout killbill-api
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-api
+          ref: refs/heads/work-for-release-0.23.x
+          path: killbill-api
+      - name: Checkout killbill-plugin-api
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-plugin-api
+          ref: refs/heads/work-for-release-0.23.x
+          path: killbill-plugin-api
       - name: Checkout killbill-commons
         uses: actions/checkout@v2
         with:
@@ -73,12 +85,14 @@ jobs:
           popd
 
           declare -A property=(
+            [killbill-api]=killbill-api.version
+            [killbill-plugin-api]=killbill-plugin-api.version
             [killbill-commons]=killbill-commons.version
             [killbill-plugin-framework-java]=killbill-base-plugin.version
             [killbill-platform]=killbill-platform.version
             [killbill-client-java]=killbill-client.version
           )
-          for i in killbill-commons killbill-plugin-framework-java killbill-platform killbill-client-java; do
+          for i in killbill-api killbill-plugin-api killbill-commons killbill-plugin-framework-java killbill-platform killbill-client-java; do
             pushd $GITHUB_WORKSPACE/$i
             echo "Resolving current $i version"
             version=$(mvn ${MAVEN_FLAGS} help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Kill Bill OSS Parent: base pom for the various Kill Bill projects.
 | 0.142.y            | 0.20.z            |
 | 0.143.y            | 0.22.z            |
 | 0.144.y            | 0.22.z            |
+| 0.145.y            | 0.23.z            |
 
 We've upgraded numerous dependencies in 0.144.x (required for Java 11 support).
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.kill-bill.billing</groupId>
     <artifactId>killbill-oss-parent</artifactId>
-    <version>0.144.74-SNAPSHOT</version>
+    <version>0.145.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Kill Bill OSS Parent</name>
     <description>Parent pom for Kill Bill projects</description>
@@ -118,12 +118,12 @@
         <jjwt.version>0.11.2</jjwt.version>
         <joda-time.version>2.10.13</joda-time.version>
         <jooby.version>1.6.9</jooby.version>
-        <killbill-api.version>0.53.17</killbill-api.version>
-        <killbill-base-plugin.version>4.2.15</killbill-base-plugin.version>
-        <killbill-client.version>1.2.5</killbill-client.version>
-        <killbill-commons.version>0.24.18</killbill-commons.version>
-        <killbill-platform.version>0.40.11</killbill-platform.version>
-        <killbill-plugin-api.version>0.26.4</killbill-plugin-api.version>
+        <killbill-api.version>0.54.0-SNAPSHOT</killbill-api.version>
+        <killbill-base-plugin.version>5.0.0-SNAPSHOT</killbill-base-plugin.version>
+        <killbill-client.version>1.3.0-SNAPSHOT</killbill-client.version>
+        <killbill-commons.version>0.25.0-SNAPSHOT</killbill-commons.version>
+        <killbill-platform.version>0.41.0-SNAPSHOT</killbill-platform.version>
+        <killbill-plugin-api.version>0.27.0-SNAPSHOT</killbill-plugin-api.version>
         <logback.version>1.2.7</logback.version>
         <metrics-palominolabs.version>3.2.2</metrics-palominolabs.version>
         <metrics.version>3.2.6</metrics.version>


### PR DESCRIPTION
CI on `work-for-release-0.23.x` will automatically run all tests against the latest `work-for-release-0.23.x` branch in all repositories.