### PR TITLE
pom.xml: relax dependency check strategy for Kill Bill artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1786,6 +1786,14 @@
                         <failBuildInCaseOfConflict>${check.fail-dependency-versions}</failBuildInCaseOfConflict>
                         <resolvers>
                             <resolver>
+                                <!-- Relaxed strategy for Kill Bill artifacts (especially useful for SNAPSHOT) -->
+                                <strategyName>two-digits-backward-compatible</strategyName>
+                                <includes>
+                                    <include>org.kill-bill.billing:*</include>
+                                    <include>org.kill-bill.billing.plugin:*</include>
+                                </includes>
+                            </resolver>
+                            <resolver>
                                 <strategyName>single-digit</strategyName>
                                 <includes>
                                     <include>com.google.guava:guava</include>


### PR DESCRIPTION
This gets rid of errors like:

```
Error:  Found a problem with the direct dependency org.kill-bill.billing:killbill-api of the current project
  Expected version is 0.54.0-324309b-SNAPSHOT
  Resolved version is 0.54.0-324309b-SNAPSHOT
  Version 0.54.0-324309b-SNAPSHOT was expected by artifact: org.kill-bill.billing:killbill-internal-api
  Version 0.54.0-SNAPSHOT was expected by artifacts: org.kill-bill.billing:killbill-platform-base, org.kill-bill.billing:killbill-platform-osgi, org.kill-bill.billing:killbill-platform-osgi-api, org.kill-bill.billing:killbill-platform-test
  Version 0.54.0-ca5c628-SNAPSHOT was expected by artifacts: org.kill-bill.billing.plugin:killbill-plugin-api-invoice, org.kill-bill.billing.plugin:killbill-plugin-api-notification
```