### PR TITLE
pom.xml: ignore requireUpperBoundDeps on killbill-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1791,6 +1791,7 @@
                                 <includes>
                                     <include>org.kill-bill.billing:*</include>
                                     <include>org.kill-bill.billing.plugin:*</include>
+                                    <include>org.kill-bill.commons:*</include>
                                 </includes>
                             </resolver>
                             <resolver>
@@ -1969,7 +1970,26 @@
                                 </includes>
                             </bannedDependencies>
                             <banDuplicatePomDependencyVersions/>
-                            <requireUpperBoundDeps/>
+                            <requireUpperBoundDeps>
+                                <excludes>
+                                    <!-- Wildcards don't seem to work -->
+                                    <exclude>org.kill-bill.commons:killbill-automaton</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-clock</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-concurrent</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-config-magic</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-embeddeddb-common</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-embeddeddb-h2</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-embeddeddb-mysql</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-embeddeddb-postgresql</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-jdbi</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-locker</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-metrics</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-metrics-api</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-queue</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-skeleton</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-xmlloader</exclude>
+                                </excludes>
+                            </requireUpperBoundDeps>
                             <requireMavenVersion>
                                 <version>3.5.2</version>
                             </requireMavenVersion>


### PR DESCRIPTION
Follow-up on https://github.com/killbill/killbill-oss-parent/pull/371.

This gets rid of errors like:

```
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT paths to dependency are:
+-org.kill-bill.billing:killbill-util:0.23.0-SNAPSHOT
  +-org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT
and
+-org.kill-bill.billing:killbill-util:0.23.0-SNAPSHOT
  +-org.kill-bill.billing:killbill-platform-base:0.41.0-f57a918-SNAPSHOT
    +-org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT (managed) <-- org.kill-bill.commons:killbill-jdbi:0.25.1-137ffd1-SNAPSHOT
and
+-org.kill-bill.billing:killbill-util:0.23.0-SNAPSHOT
  +-org.kill-bill.billing:killbill-platform-lifecycle:0.41.0-f57a918-SNAPSHOT
    +-org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT (managed) <-- org.kill-bill.commons:killbill-jdbi:0.25.1-137ffd1-SNAPSHOT
and
+-org.kill-bill.billing:killbill-util:0.23.0-SNAPSHOT
  +-org.kill-bill.billing:killbill-platform-osgi:0.41.0-f57a918-SNAPSHOT
    +-org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT (managed) <-- org.kill-bill.commons:killbill-jdbi:0.25.1-137ffd1-SNAPSHOT
and
+-org.kill-bill.billing:killbill-util:0.23.0-SNAPSHOT
  +-org.kill-bill.billing:killbill-platform-test:0.41.0-f57a918-SNAPSHOT
    +-org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT (managed) <-- org.kill-bill.commons:killbill-jdbi:0.25.1-137ffd1-SNAPSHOT
and
+-org.kill-bill.billing:killbill-util:0.23.0-SNAPSHOT
  +-org.kill-bill.commons:killbill-queue:0.25.1-2f451be-SNAPSHOT
    +-org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT (managed) <-- org.kill-bill.commons:killbill-jdbi:0.25.1-137ffd1-SNAPSHOT
and
+-org.kill-bill.billing:killbill-util:0.23.0-SNAPSHOT
  +-org.kill-bill.commons:killbill-queue:0.25.1-2f451be-SNAPSHOT
    +-org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT (managed) <-- org.kill-bill.commons:killbill-jdbi:0.25.1-137ffd1-SNAPSHOT
and
+-org.kill-bill.billing:killbill-util:0.23.0-SNAPSHOT
  +-org.kill-bill.billing:killbill-platform-test:0.41.0-f57a918-SNAPSHOT
    +-org.kill-bill.billing:killbill-platform-base:0.41.0-f57a918-SNAPSHOT
      +-org.kill-bill.commons:killbill-jdbi:0.25.1-2f451be-SNAPSHOT (managed) <-- org.kill-bill.commons:killbill-jdbi:0.25.1-137ffd1-SNAPSHOT
]
```