### PR TITLE
pom.xml: add osgi.annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <metrics.version>4.2.9</metrics.version>
         <netty.version>4.1.76.Final</netty.version>
         <osgi.activator>$${classes;EXTENDS;org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase}</osgi.activator>
+        <osgi.annotation.version>8.1.0</osgi.annotation.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <osgi.dependency>*;scope=compile|runtime;inline=true</osgi.dependency>
         <osgi.description>${project.description}</osgi.description>
@@ -1546,6 +1547,11 @@
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.compendium</artifactId>
                 <version>${osgi.compendium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.annotation</artifactId>
+                <version>${osgi.annotation.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>


### PR DESCRIPTION
Addresses:
```
Warning:  Rule 2: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.osgi:osgi.annotation:6.0.1 [provided] paths to dependency are:
+-org.kill-bill.billing:killbill-jaxrs:0.23.0-SNAPSHOT
  +-org.kill-bill.billing:killbill-platform-server:0.41.0-SNAPSHOT:classes
    +-org.kill-bill.billing:killbill-platform-osgi:0.41.0-SNAPSHOT (managed) <-- org.kill-bill.billing:killbill-platform-osgi:0.41.0-SNAPSHOT
      +-org.apache.felix:org.apache.felix.framework:7.0.3 (managed) <-- org.apache.felix:org.apache.felix.framework:7.0.3
        +-org.apache.felix:org.apache.felix.resolver:2.0.4 [provided]
          +-org.osgi:osgi.annotation:6.0.1 [provided]
and
+-org.kill-bill.billing:killbill-jaxrs:0.23.0-SNAPSHOT
  +-org.kill-bill.billing:killbill-platform-server:0.41.0-SNAPSHOT:classes
    +-org.kill-bill.commons:killbill-skeleton:0.25.1-SNAPSHOT (managed) <-- org.kill-bill.commons:killbill-skeleton:0.25.1-SNAPSHOT
      +-org.glassfish.jersey.core:jersey-common:2.35 (managed) <-- org.glassfish.jersey.core:jersey-common:2.35
        +-org.glassfish.hk2:osgi-resource-locator:1.0.3
          +-org.osgi:osgi.core:8.0.0 [provided] (managed) <-- org.osgi:osgi.core:6.0.0 [provided]
            +-org.osgi:osgi.annotation:7.0.0 [provided]
]
```