### PR TITLE
add killbill-commons/killbill-utils as dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1457,6 +1457,11 @@
             </dependency>
             <dependency>
                 <groupId>org.kill-bill.commons</groupId>
+                <artifactId>killbill-utils</artifactId>
+                <version>${killbill-commons.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kill-bill.commons</groupId>
                 <artifactId>killbill-xmlloader</artifactId>
                 <version>${killbill-commons.version}</version>
             </dependency>
@@ -1942,6 +1947,7 @@
                                     <exclude>org.kill-bill.commons:killbill-metrics-api</exclude>
                                     <exclude>org.kill-bill.commons:killbill-queue</exclude>
                                     <exclude>org.kill-bill.commons:killbill-skeleton</exclude>
+                                    <exclude>org.kill-bill.commons:killbill-utils</exclude>
                                     <exclude>org.kill-bill.commons:killbill-xmlloader</exclude>
                                 </excludes>
                             </requireUpperBoundDeps>


### PR DESCRIPTION
As discussed [here](https://github.com/killbill/killbill-commons/pull/132#discussion_r902654061). I also add `<exclude>org.kill-bill.commons:killbill-utils</exclude>` just like other modules, but not sure if I should.