### PR TITLE
update various killbill artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,12 +124,12 @@
         <jjwt.version>0.11.5</jjwt.version>
         <joda-time.version>2.10.14</joda-time.version>
         <jooby.version>1.6.9</jooby.version>
-        <killbill-api.version>0.54.0-9f8a501-SNAPSHOT</killbill-api.version>
-        <killbill-base-plugin.version>5.0.0-50df228-SNAPSHOT</killbill-base-plugin.version>
+        <killbill-api.version>0.54.0-484670d-SNAPSHOT</killbill-api.version>
+        <killbill-base-plugin.version>5.0.0-3620a12-SNAPSHOT</killbill-base-plugin.version>
         <killbill-client.version>1.3.0-22ee96a-SNAPSHOT</killbill-client.version>
-        <killbill-commons.version>0.25.1-775465f-SNAPSHOT</killbill-commons.version>
-        <killbill-platform.version>0.41.0-637c799-SNAPSHOT</killbill-platform.version>
-        <killbill-plugin-api.version>0.27.0-560c5b7-SNAPSHOT</killbill-plugin-api.version>
+        <killbill-commons.version>0.25.1-2361a7d-SNAPSHOT</killbill-commons.version>
+        <killbill-platform.version>0.41.0-642a42b-SNAPSHOT</killbill-platform.version>
+        <killbill-plugin-api.version>0.27.0-f59cc90-SNAPSHOT</killbill-plugin-api.version>
         <logback.version>1.2.11</logback.version>
         <metrics.version>4.2.10</metrics.version>
         <netty.version>4.1.74.Final</netty.version>


### PR DESCRIPTION
- killbill-api: from 9f8a501 (May 12) to 484670d (Aug 8)
- killbill-base-plugin: from 50df228 (May 4) to 3620a12 (Jul 14)
- killbill-commons: from 775465f (May 14) to 2361a7d (Aug 9)
- killbill-platform: from 637c799 (Jul 22) to 642a42b (Aug 11)
- killbill-plugin-api: from 560c5b7 (May 4) to f59cc90 (Jul 15)

This updates tested against (current work-for-release branch) in `killbill-commons` and `killbill-platform`, against `fast` and `slow` tests.