### PR TITLE
remove slf4j from dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,3 @@ updates:
     - dependency-name: org.jooq:*
       versions:
         - ">= 3.16.0"
-    - dependency-name: org.slf4j:*
-      versions:
-        - ">= 2.0.0"


### PR DESCRIPTION
I think what I need to do is just remove slf4j from dependabot ignore, then wait dependabot create PR for slf4j 2.0.x. Am I doing wrong?