### PR TITLE
update transitive dependencies for tech-support-57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,11 @@
                 <version>${guice.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.16.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>1.4.200</version>
@@ -384,6 +389,11 @@
                         <!-- We use jakarta.validation:jakarta.validation-api instead -->
                         <groupId>javax.validation</groupId>
                         <artifactId>validation-api</artifactId>
+                    </exclusion>
+                    <!-- needed for updating dropwizard-validation version -->
+                    <exclusion>
+                        <groupId>io.dropwizard</groupId>
+                        <artifactId>dropwizard-validation</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -463,6 +473,11 @@
                 <groupId>io.airlift</groupId>
                 <artifactId>units</artifactId>
                 <version>1.6</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-validation</artifactId>
+                <version>1.3.21</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
@@ -1084,6 +1099,11 @@
                 <artifactId>hamcrest-library</artifactId>
                 <version>2.2</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>5.2.5.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.influxdb</groupId>


### PR DESCRIPTION
Issue: https://github.com/killbill/technical-support/issues/57

Affected JAR: protobuf-java, dropwizard-validation, and hibernate-validator.

Exclusion for dropwizard-validation in dropwizard-metrics-influxdb needed otherwise enforcer plugin complaining about it.