### PR TITLE
merge master to work-for-release-0.23.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <shiro.version>1.9.1</shiro.version>
         <skipTests>false</skipTests>
         <slf4j.version>1.7.36</slf4j.version>
-        <surefireArgLine>-Xmx${build.jvmsize} -XX:MaxDirectMemorySize=512m</surefireArgLine>
+        <surefireArgLine>-Xmx${build.jvmsize} --illegal-access=permit</surefireArgLine>
         <swagger.version>1.6.6</swagger.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
There are some dependency that I leave it in master (it is exist because of https://github.com/killbill/technical-support/issues/57):
```xml
<dependency>
    <groupId>com.google.protobuf</groupId>
    <artifactId>protobuf-java</artifactId>
    <version>3.16.1</version>
</dependency>

<dependency>
    <groupId>org.hibernate.validator</groupId>
    <artifactId>hibernate-validator</artifactId>
    <version>5.2.5.Final</version>
</dependency>
```

If you think that this is should exist in `work-for-release-0.23.x`, let me know.