### PR TITLE
Downgrade derby version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,3 +58,7 @@ updates:
     - dependency-name: org.jooq:*
       versions:
         - ">= 3.16.0"
+    # derby 10.16.x require Java 17
+    - dependency-name: org.apache.derby:*
+      versions:
+        - ">= 10.16.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -605,7 +605,7 @@
             <dependency>
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
-                <version>10.16.1.1</version>
+                <version>10.15.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
I was [wrong](https://github.com/killbill/killbill-oss-parent/pull/498#issuecomment-1244886349), derby 10.16.x.x require java 17. This PR attempt to revert it back. 

Also to follow up [this issue](https://github.com/killbill/killbill-oss-parent/issues/557), I added derby to `dependabot.yml`, but I'm not sure if the [version format](https://github.com/xsalefter/killbill-oss-parent/blob/e5df3d4a737ae81e1b5e4b0bbe557420fe2e218b/.github/dependabot.yml#L64) that I put in there is correct. 