### PR TITLE
Downgrade annotation api version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,3 +62,10 @@ updates:
     - dependency-name: org.apache.derby:*
       versions:
         - ">= 10.16.0.0"
+    # Some problems:
+    #   - annotation-api 2.x start using jakarta.* instead of javax.*
+    #   - attempt to update jersey version to 3.x.x (to match jakarta.annotation 2.x.x version) will fail because
+    #     HttpServlet not in javax.http anymore
+    - dependency-name: jakarta.annotation:*
+      versions:
+        - ">= 2.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <guice.version>5.1.0</guice.version>
         <hk2.version>2.6.1</hk2.version>
         <jackson.version>2.13.4</jackson.version>
-        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
+        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
         <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>


### PR DESCRIPTION
[This](https://github.com/killbill/killbill-oss-parent/pull/505) also wrong. See comment in dependabot.yml for more.