### PR TITLE
change derby ignore version format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,7 +61,7 @@ updates:
     # derby 10.16.x require Java 17
     - dependency-name: org.apache.derby:*
       versions:
-        - ">= 10.16.0.0"
+        - ">= 10.16"
     # Some problems:
     #   - annotation-api 2.x start using jakarta.* instead of javax.*
     #   - attempt to update jersey version to 3.x.x (to match jakarta.annotation 2.x.x version) will fail because


### PR DESCRIPTION
Dependabot [keep asking](https://github.com/killbill/killbill-oss-parent/pull/618) update for derby despite [we ask to not to](https://github.com/killbill/killbill-oss-parent/blob/work-for-release-0.23.x/.github/dependabot.yml#L64). Update the `versions` format may fix the problem. Or if you know something better to fix this, let me know.