### PR TITLE
Revert osgi log to 1.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,9 @@ updates:
     - dependency-name: jakarta.annotation:*
       versions:
         - ">= 2.0.0"
+    # Start from 1.4.0, LogService implements LoggerFactory. See:
+    # - 1.3.0 : https://docs.osgi.org/javadoc/r6/enterprise/org/osgi/service/log/LogService.html
+    # - 1.4.0 : https://docs.osgi.org/javadoc/osgi.cmpn/7.0.0/org/osgi/service/log/LogService.html
+    - dependency-name: org.osgi:org.osgi.service.log
+      versions:
+        - ">= 1.4.0"

--- a/pom.xml
+++ b/pom.xml
@@ -1510,7 +1510,7 @@
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.log</artifactId>
-                <version>1.5.0</version>
+                <version>1.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>


### PR DESCRIPTION
[This](https://github.com/killbill/killbill-oss-parent/pull/464) is causing compile time error: Start from osgi log 1.4.0, `LogService` implements `org.osgi.service.log.LoggerFactory`.