### PR TITLE
remove testing-postgresql-server and update killbill-base-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <!-- We cannot upgrade to 3.15.x, yet. See https://github.com/killbill/killbill-oss-parent/issues/552 -->
         <jooq.version>3.15.12</jooq.version>
         <killbill-api.version>0.54.0-484670d-SNAPSHOT</killbill-api.version>
-        <killbill-base-plugin.version>5.0.0-d351c34-SNAPSHOT</killbill-base-plugin.version>
+        <killbill-base-plugin.version>5.0.0-aa650a0-SNAPSHOT</killbill-base-plugin.version>
         <killbill-client.version>1.3.0-22ee96a-SNAPSHOT</killbill-client.version>
         <killbill-commons.version>0.25.1-24a3b5f-SNAPSHOT</killbill-commons.version>
         <killbill-platform.version>0.41.0-fcc3d99-SNAPSHOT</killbill-platform.version>
@@ -429,11 +429,6 @@
                 <groupId>io.airlift</groupId>
                 <artifactId>testing-mysql-server</artifactId>
                 <version>8.0.12-5</version>
-            </dependency>
-            <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>testing-postgresql-server</artifactId>
-                <version>9.6.3-3</version>
             </dependency>
             <dependency>
                 <groupId>io.airlift</groupId>


### PR DESCRIPTION
Last step of https://github.com/killbill/killbill-oss-parent/issues/619 : delete `testing-postgresql-server` from oss-parent.