### PR TITLE
Removed com.sun.activation:jakarta.activation from banned dependences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <check.skip-enforcer>false</check.skip-enforcer>
         <check.skip-rat>false</check.skip-rat>
         <check.skip-spotbugs>false</check.skip-spotbugs>
-        <check.spotbugs-exclude-filter-file />
+        <check.spotbugs-exclude-filter-file/>
         <compiler.fail-warnings>false</compiler.fail-warnings>
         <deploy.deploy-at-end>true</deploy.deploy-at-end>
         <derby.version>10.15.2.0</derby.version>
@@ -146,8 +146,8 @@
         <osgi.annotation.version>8.1.0</osgi.annotation.version>
         <osgi.dependency>*;scope=compile|runtime;inline=true</osgi.dependency>
         <osgi.description>${project.description}</osgi.description>
-        <osgi.export />
-        <osgi.extra-import />
+        <osgi.export/>
+        <osgi.extra-import/>
         <osgi.fixupmessages>"Classes found in the wrong directory...","Unused Import-Package instructions...","While traversing the type tree for...";is:=ignore</osgi.fixupmessages>
         <osgi.import>
             ${osgi.extra-import},
@@ -211,7 +211,7 @@
         </osgi.import>
         <osgi.name>${project.name}</osgi.name>
         <osgi.noclassforname>true</osgi.noclassforname>
-        <osgi.private />
+        <osgi.private/>
         <osgi.symbolic-name>${project.groupId}.${project.artifactId}</osgi.symbolic-name>
         <osgi.transitive-dependency>true</osgi.transitive-dependency>
         <osgi.version>8.0.0</osgi.version>
@@ -1877,8 +1877,6 @@
                                     <exclude>com.google.guava:listenablefuture</exclude>
                                     <!-- Contains FindBugs annotations, JSR-305 and JCIP annotations -->
                                     <exclude>com.google.code.findbugs:annotations</exclude>
-                                    <!-- Replaced with jakarta.activation:jakarta.activation-api -->
-                                    <exclude>com.sun.activation:jakarta.activation</exclude>
                                     <exclude>javax.activation:javax.activation</exclude>
                                     <exclude>javax.activation:javax.activation-api</exclude>
                                     <!-- Replaced with jakarta.servlet:jakarta.servlet-api -->
@@ -1905,7 +1903,7 @@
                                     <include>junit:junit:[4.11,)</include>
                                 </includes>
                             </bannedDependencies>
-                            <banDuplicatePomDependencyVersions />
+                            <banDuplicatePomDependencyVersions/>
                             <requireUpperBoundDeps>
                                 <excludes>
                                     <!-- Wildcards don't seem to work -->
@@ -2149,8 +2147,8 @@
                                 <skip>${check.skip-rat}</skip>
                                 <ignoreErrors>${check.ignore-rat}</ignoreErrors>
                                 <licenseFamilies>
-                                    <licenseFamily implementation="org.apache.rat.license.Apache20LicenseFamily" />
-                                    <licenseFamily implementation="org.apache.rat.license.MITLicenseFamily" />
+                                    <licenseFamily implementation="org.apache.rat.license.Apache20LicenseFamily"/>
+                                    <licenseFamily implementation="org.apache.rat.license.MITLicenseFamily"/>
                                 </licenseFamilies>
                                 <useDefaultExcludes>true</useDefaultExcludes>
                                 <parseSCMIgnoresAsExcludes>true</parseSCMIgnoresAsExcludes>


### PR DESCRIPTION
There is an issue in the email notification plugin after merging `0.23.x` into `master`, it fails to send emails with the following error in the log file:

```
Caused by: java.lang.NoClassDefFoundError: com/sun/activation/registries/LogSupport
	at javax.activation.MailcapCommandMap.<init>(MailcapCommandMap.java:149)
	at javax.activation.CommandMap.getDefaultCommandMap(CommandMap.java:55)
	at javax.activation.DataHandler.getCommandMap(DataHandler.java:137)
	at javax.activation.DataHandler.getDataContentHandler(DataHandler.java:599)
	at javax.activation.DataHandler.writeTo(DataHandler.java:299)
	at javax.mail.internet.MimeUtility.getEncoding(MimeUtility.java:340)
	at javax.mail.internet.MimeBodyPart.updateHeaders(MimeBodyPart.java:1575)
	at javax.mail.internet.MimeBodyPart.updateHeaders(MimeBodyPart.java:1172)
	at javax.mail.internet.MimeMultipart.updateHeaders(MimeMultipart.java:522)
	at javax.mail.internet.MimeBodyPart.updateHeaders(MimeBodyPart.java:1533)
	at javax.mail.internet.MimeMessage.updateHeaders(MimeMessage.java:2271)
	at javax.mail.internet.MimeMessage.saveChanges(MimeMessage.java:2231)
	at javax.mail.Transport.send(Transport.java:123)
	at org.apache.commons.mail.Email.sendMimeMessage(Email.java:1459)
```

Simply adding the `com.sun.activation:jakarta.activation` dependency in the `email-notification plugin/pom.xml` caused an enforcer rule to fail with the following error:

```
[ERROR] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: com.sun.activation:jakarta.activation:jar:2.0.0
```

So, I removed the `com.sun.activation:jakarta.activation` from banned dependences (in this PR). I've tested the email notification plugin with this change on local and it works fine, emails are getting sent. 

If this change looks good, I will release a new version of `oss-parent` with this change and use this in the email notification plugin. 