### PR TITLE
update actions/checkout@v2 to v3 and actions/setup-java to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,59 +41,59 @@ jobs:
           - refs/heads/master
     steps:
       - name: Checkout killbill-oss-parent
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: killbill/killbill-oss-parent
           path: killbill-oss-parent
       - name: Checkout killbill-api
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: killbill/killbill-api
           ref: ${{ matrix.ref-api }}
           path: killbill-api
       - name: Checkout killbill-plugin-api
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: killbill/killbill-plugin-api
           ref: ${{ matrix.ref-plugin-api }}
           path: killbill-plugin-api
       - name: Checkout killbill-commons
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: killbill/killbill-commons
           ref: ${{ matrix.ref-commons }}
           path: killbill-commons
       - name: Checkout killbill-plugin-framework-java
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: killbill/killbill-plugin-framework-java
           ref: ${{ matrix.ref-plugin-framework-java }}
           path: killbill-plugin-framework-java
       - name: Checkout killbill-platform
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: killbill/killbill-platform
           ref: ${{ matrix.ref-platform }}
           path: killbill-platform
       - name: Checkout killbill-client-java
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: killbill/killbill-client-java
           ref: ${{ matrix.ref-client-java }}
           path: killbill-client-java
       - name: Checkout killbill
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: killbill/killbill
           ref: ${{ matrix.ref-killbill }}
           path: killbill
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
       - name: Configure Sonatype mirror
-        uses: s4u/maven-settings-action@v2.4.1
+        uses: s4u/maven-settings-action@v2.8.0
         # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://oss.sonatype.org/content/repositories/releases"}]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - name: Checkout code
         if: github.event.inputs.perform_version == ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout full repository
         # Required when performing an existing release.
         if: github.event.inputs.perform_version != ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - name: Setup git user
@@ -50,11 +50,11 @@ jobs:
           git config --global user.name "Kill Bill core team"
           git config --global url."https://${BUILD_USER}:${BUILD_TOKEN}@github.com/".insteadOf "git@github.com:"
       - name: Configure Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
       - name: Configure Sonatype mirror
-        uses: s4u/maven-settings-action@v2.3.0
+        uses: s4u/maven-settings-action@v2.8.0
         # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "*", "url": "https://oss.sonatype.org/content/repositories/releases/"}]'
@@ -119,7 +119,7 @@ jobs:
           # Will be pushed as part of the release process, only if the release is successful
           git commit -m "pom.xml: update killbill-client to ${{ github.event.inputs.java_client_version }}"
       - name: Configure settings.xml for release
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           server-id: ossrh-releases


### PR DESCRIPTION
1. Attempt to fix [this issue](https://github.com/killbill/killbill-oss-parent/issues/656). 
2. Create branch from `killbill` instead of my account to avoid private configurations/keys/secrets that will not being called/used.
3. I actually not sure the best way to get "latest version of action". In this case, I just use the major version (`v3`) instead of fully semver version (`v.3.3.0`). I have feeling that `actions/checkout@v3` will use latest 3.x.x version, but I don't have any backup for this statement :man_shrugging: . If I need to set `actions/checkout@v3.3.0` instead, let me know.