### PR TITLE
Oss 751 add release repo dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: release
 
 on:
+  repository_dispatch:
+    types: [update_kb_commons_version, update_kb_base_plugin_version, update_kb_platform_version, update_kb_client_version]
+
   workflow_dispatch:
     inputs:
       commons_version:


### PR DESCRIPTION
Original issue: https://github.com/killbill/killbill-oss-parent/issues/751

See complete explanation here: https://github.com/killbill/gh-actions-shared/pull/41