### PR TITLE
Update jooby version 1.6.9 -> 3.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,8 @@
         <jetty.version>10.0.16</jetty.version>
         <jjwt.version>0.11.5</jjwt.version>
         <joda-time.version>2.12.5</joda-time.version>
-        <jooby.version>3.0.7</jooby.version>
+        <org.jooby.version>1.6.9</org.jooby.version>
+        <io.jooby.version>3.0.7</io.jooby.version>
         <!-- We cannot upgrade to 3.16.x, yet. See
              https://github.com/killbill/killbill-oss-parent/issues/557
              https://github.com/killbill/killbill-oss-parent/pull/411 -->
@@ -945,7 +946,7 @@
             <dependency>
                 <groupId>org.jooby</groupId>
                 <artifactId>jooby-servlet</artifactId>
-                <version>${jooby.version}</version>
+                <version>${org.jooby.version}</version>
                 <exclusions>
                     <exclusion>
                         <!-- We use jakarta.servlet:jakarta.servlet-api instead -->
@@ -953,6 +954,11 @@
                         <artifactId>javax.servlet-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.jooby</groupId>
+                <artifactId>jooby-servlet</artifactId>
+                <version>${io.jooby.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jooq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <jetty.version>10.0.16</jetty.version>
         <jjwt.version>0.11.5</jjwt.version>
         <joda-time.version>2.12.5</joda-time.version>
-        <jooby.version>1.6.9</jooby.version>
+        <jooby.version>3.0.7</jooby.version>
         <!-- We cannot upgrade to 3.16.x, yet. See
              https://github.com/killbill/killbill-oss-parent/issues/557
              https://github.com/killbill/killbill-oss-parent/pull/411 -->


### PR DESCRIPTION
Hello team,

I recently wondered about how `killbill `works on `java versions` higher than 11. [I asked a question in the Mailing-List](https://groups.google.com/g/killbilling-users/c/6nn-lnb6Kkg), Karan answered me and gave a positive response for the pull request.

In these changes, I am raising the `jooby` version to unlock work with java version higher than 11, because `jooby` had a problem with the transitive dependency of `ASM`, which blocked the work of current versions of `java`. 

- `ASM` has made java support on its side https://gitlab.ow2.org/asm/asm/-/issues/317990
- `jooby` updated the `ASM` dependency to version 9.3, which has `java 21` support https://github.com/jooby-project/jooby/blob/61573ee27c16830245792532be2a68601c689f7f/pom.xml#L69
- `killbill-oss-parent` can update `jooby`dependency

issues https://github.com/killbill/killbill-oss-parent/issues/40