### PR TITLE
killbill 0.26.x snapshots support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,59 +47,59 @@ jobs:
           - postgresql
     steps:
       - name: Checkout killbill-oss-parent
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: killbill/killbill-oss-parent
           path: killbill-oss-parent
       - name: Checkout killbill-api
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: killbill/killbill-api
           ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
           path: killbill-api
       - name: Checkout killbill-plugin-api
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: killbill/killbill-plugin-api
           ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
           path: killbill-plugin-api
       - name: Checkout killbill-commons
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: killbill/killbill-commons
           ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
           path: killbill-commons
       - name: Checkout killbill-plugin-framework-java
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: killbill/killbill-plugin-framework-java
           ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
           path: killbill-plugin-framework-java
       - name: Checkout killbill-platform
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: killbill/killbill-platform
           ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
           path: killbill-platform
       - name: Checkout killbill-client-java
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: killbill/killbill-client-java
           ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
           path: killbill-client-java
       - name: Checkout killbill
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: killbill/killbill
           ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
           path: killbill
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
       - name: Configure Sonatype mirror
-        uses: s4u/maven-settings-action@v2.8.0
+        uses: s4u/maven-settings-action@v4.0.0
         # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://repo.maven.apache.org/maven2"}]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         uses: s4u/maven-settings-action@v2.8.0
         # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
         with:
-          mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://oss.sonatype.org/content/repositories/releases"}]'
+          mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://repo.maven.apache.org/maven2"}]'
           sonatypeSnapshots: true
       - name: Download dependencies and setup the various pom.xml
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,28 +10,7 @@ env:
   MAVEN_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
 
 jobs:
-  resolve-branch-refs:
-    runs-on: ubuntu-22.04
-    outputs:
-      ci-ref: ${{ steps.refs.outputs.ci-ref }}
-    steps:
-      - name: Resolve CI branch refs
-        id: refs
-        shell: bash
-        run: |
-          branch=master
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "java2x" ]]; then
-            branch=java2x
-          elif [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" == "java2x" ]]; then
-            branch=java2x
-          fi
-
-          echo "ci-ref=refs/heads/$branch" >> "$GITHUB_OUTPUT"
-          echo "Using downstream CI ref refs/heads/$branch"
-
   tests:
-    needs:
-      - resolve-branch-refs
     runs-on: ubuntu-22.04
     timeout-minutes: 200
     strategy:
@@ -45,6 +24,20 @@ jobs:
           - h2
           - mysql
           - postgresql
+        ref-api:
+          - refs/heads/java2x
+        ref-plugin-api:
+          - refs/heads/java2x
+        ref-commons:
+          - refs/heads/java2x
+        ref-plugin-framework-java:
+          - refs/heads/java2x
+        ref-platform:
+          - refs/heads/java2x
+        ref-client-java:
+          - refs/heads/java2x
+        ref-killbill:
+          - refs/heads/java2x
     steps:
       - name: Checkout killbill-oss-parent
         uses: actions/checkout@v6
@@ -55,43 +48,43 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: killbill/killbill-api
-          ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
+          ref: ${{ matrix.ref-api }}
           path: killbill-api
       - name: Checkout killbill-plugin-api
         uses: actions/checkout@v6
         with:
           repository: killbill/killbill-plugin-api
-          ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
+          ref: ${{ matrix.ref-plugin-api }}
           path: killbill-plugin-api
       - name: Checkout killbill-commons
         uses: actions/checkout@v6
         with:
           repository: killbill/killbill-commons
-          ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
+          ref: ${{ matrix.ref-commons }}
           path: killbill-commons
       - name: Checkout killbill-plugin-framework-java
         uses: actions/checkout@v6
         with:
           repository: killbill/killbill-plugin-framework-java
-          ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
+          ref: ${{ matrix.ref-plugin-framework-java }}
           path: killbill-plugin-framework-java
       - name: Checkout killbill-platform
         uses: actions/checkout@v6
         with:
           repository: killbill/killbill-platform
-          ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
+          ref: ${{ matrix.ref-platform }}
           path: killbill-platform
       - name: Checkout killbill-client-java
         uses: actions/checkout@v6
         with:
           repository: killbill/killbill-client-java
-          ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
+          ref: ${{ matrix.ref-client-java }}
           path: killbill-client-java
       - name: Checkout killbill
         uses: actions/checkout@v6
         with:
           repository: killbill/killbill
-          ref: ${{ needs.resolve-branch-refs.outputs.ci-ref }}
+          ref: ${{ matrix.ref-killbill }}
           path: killbill
       - name: Setup Java
         uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - name: Checkout code
         if: github.event.inputs.perform_version == ''
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Checkout full repository
         # Required when performing an existing release.
         if: github.event.inputs.perform_version != ''
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: Setup git user
@@ -50,9 +50,9 @@ jobs:
           git config --global user.name "Kill Bill core team"
           git config --global url."https://${BUILD_USER}:${BUILD_TOKEN}@github.com/".insteadOf "git@github.com:"
       - name: Configure Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: temurin
       - name: Download Java dependencies
         # We do as much as we can, but it may not be enough (https://issues.apache.org/jira/browse/MDEP-82)
@@ -115,9 +115,9 @@ jobs:
           # Will be pushed as part of the release process, only if the release is successful
           git commit -m "pom.xml: update killbill-client to ${{ github.event.inputs.java_client_version }}"
       - name: Configure settings.xml for release
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: temurin
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,5 @@ Temporary Items
 *.tmproj
 *.tmproject
 tmtags
+/.codex
+/.idea/copilot.data.migration.ask2agent.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>

--- a/Java2x-WIP.md
+++ b/Java2x-WIP.md
@@ -12,18 +12,11 @@ This document is the master task board for the Java 2x migration.
 
 ### Current WIP
 
-Work on `.agents/tasks/java-2x-migrate/8-JAVA21_BASELINE_AND_VALIDATION.md`.
-Task 2 is complete in `killbill-commons`, and `killbill-commons` release CI has
-been updated to Java `21`. The remaining CI work is now in
-`killbill-oss-parent`: align the parent POM, normal CI, and release workflow
-with the Java 21 baseline before downstream production adoption.
-
-Example:
-
-Work on `.agents/tasks/java-2x-migrate/2-GUICE_AND_SERVLET_FOUNDATION.md`.
-Code migration for guice is completed.
-Library up-to-date.
-Still fixing unit tests.
+Tasks 1–3 and 8 are complete for `killbill-oss-parent`. Task 7 is partially
+done (major libraries upgraded, minor families remain). Remaining open work
+is downstream runtime adoption in `killbill-platform` (Task 4),
+`killbill-plugin-framework-java` / Jooby (Task 5), and the `killbill` app
+layer (Task 6).
 
 ## Task Directory
 
@@ -39,10 +32,10 @@ Start here:
 
 - [x] [`1-CI_FOR_JAVA2X_BRANCHES.md`](./.agents/tasks/java-2x-migrate/1-CI_FOR_JAVA2X_BRANCHES.md)
 - [x] [`2-GUICE_AND_SERVLET_FOUNDATION.md`](./.agents/tasks/java-2x-migrate/2-GUICE_AND_SERVLET_FOUNDATION.md)
-- [ ] [`3-JERSEY_JETTY_AND_HK2_ALIGNMENT.md`](./.agents/tasks/java-2x-migrate/3-JERSEY_JETTY_AND_HK2_ALIGNMENT.md)
+- [x] [`3-JERSEY_JETTY_AND_HK2_ALIGNMENT.md`](./.agents/tasks/java-2x-migrate/3-JERSEY_JETTY_AND_HK2_ALIGNMENT.md) — Jersey 3.1.11, HK2 3.0.6, Jetty 11.0.26, JAX-RS 3.1.0, Swagger 2.2.28. Parent BOM aligned.
 - [ ] [`4-PLATFORM_OSGI_AND_LOGGING_RUNTIME.md`](./.agents/tasks/java-2x-migrate/4-PLATFORM_OSGI_AND_LOGGING_RUNTIME.md)
 - [ ] [`5-JOOBY_AND_PLUGIN_RUNTIME.md`](./.agents/tasks/java-2x-migrate/5-JOOBY_AND_PLUGIN_RUNTIME.md)
 - [ ] [`6-SHIRO_WEB_AND_APPLICATION_ADOPTION.md`](./.agents/tasks/java-2x-migrate/6-SHIRO_WEB_AND_APPLICATION_ADOPTION.md)
-- [ ] [`7-SUPPORTING_LIBRARY_UPGRADES.md`](./.agents/tasks/java-2x-migrate/7-SUPPORTING_LIBRARY_UPGRADES.md)
-- [ ] [`8-JAVA21_BASELINE_AND_VALIDATION.md`](./.agents/tasks/java-2x-migrate/8-JAVA21_BASELINE_AND_VALIDATION.md)
+- [~] [`7-SUPPORTING_LIBRARY_UPGRADES.md`](./.agents/tasks/java-2x-migrate/7-SUPPORTING_LIBRARY_UPGRADES.md) — Done: Jackson 2.21.2, Logback 1.5.32, Metrics 4.2.38, Ehcache 3.11.1, Shiro 2.0.6, Netty 4.2.7 (pinned — hard-won cross-repo match), Javassist 3.30.2, JAXB 4.0.x. Remaining: jOOQ (blocked #557), Derby, ANTLR, OSGi log.
+- [x] [`8-JAVA21_BASELINE_AND_VALIDATION.md`](./.agents/tasks/java-2x-migrate/8-JAVA21_BASELINE_AND_VALIDATION.md) — POM targetJdk=21, CI matrix Java 21, enforcer rules, release workflow all aligned.
 - [ ] [`99-CI_RETURN_TO_MASTER.md`](./.agents/tasks/java-2x-migrate/99-CI_RETURN_TO_MASTER.md)

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <jackson.version>2.21.2</jackson.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <!--
         Tempted to update directly to 6.x, but the answer of prompt below hold me back:
         "jakarta servlet 5 vs 6 vs 6.1 is there any breaking changes from 5 to 6.x"
@@ -521,6 +522,11 @@
                 <version>${jakarta.annotation-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
                 <version>${jakarta.servlet-api.version}</version>
@@ -544,11 +550,6 @@
                 <groupId>javax.cache</groupId>
                 <artifactId>cache-api</artifactId>
                 <version>1.1.1</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>1</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1937,7 +1937,7 @@
                         <dependency>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>extra-enforcer-rules</artifactId>
-                            <version>1.6.1</version>
+                            <version>1.12.0</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <killbill-platform.version>0.42.0-35b289e-SNAPSHOT</killbill-platform.version>
         <killbill-plugin-api.version>0.28.0-b8017ea-SNAPSHOT</killbill-plugin-api.version>
         <killbill-testing-mysql.version>1.0.2</killbill-testing-mysql.version>
-        <logback.version>1.3.14</logback.version>
+        <logback.version>1.5.32</logback.version>
         <metrics.version>4.2.12</metrics.version>
         <netty.version>4.1.84.Final</netty.version>
         <org.osgi.core.version>6.0.0</org.osgi.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <skipTests>false</skipTests>
         <slf4j.version>2.0.17</slf4j.version>
         <surefireArgLine>-Xmx${build.jvmsize} --illegal-access=permit</surefireArgLine>
-        <swagger.version>1.6.7</swagger.version>
+        <swagger.version>2.2.28</swagger.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -462,30 +462,23 @@
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-annotations</artifactId>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations-jakarta</artifactId>
                 <version>${swagger.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-jaxrs</artifactId>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-integration-jakarta</artifactId>
                 <version>${swagger.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <!-- We use jakarta.ws.rs:jakarta.ws.rs-api instead -->
-                        <groupId>javax.ws.rs</groupId>
-                        <artifactId>jsr311-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <!-- We use jakarta.validation:jakarta.validation-api instead -->
-                        <groupId>javax.validation</groupId>
-                        <artifactId>validation-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-models</artifactId>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-jaxrs2-jakarta</artifactId>
+                <version>${swagger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-models-jakarta</artifactId>
                 <version>${swagger.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
              https://github.com/killbill/killbill-oss-parent/issues/557
              https://github.com/killbill/killbill-oss-parent/pull/411 -->
         <jooq.version>3.15.12</jooq.version>
-        <killbill-api.version>0.55.0-370fa77-SNAPSHOT</killbill-api.version>
+        <killbill-api.version>0.55.0-6402be0-SNAPSHOT</killbill-api.version>
         <killbill-base-plugin.version>5.2.0-a5c0ade-SNAPSHOT</killbill-base-plugin.version>
         <killbill-client.version>1.3.11</killbill-client.version>
         <killbill-commons.version>0.27.0</killbill-commons.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,9 @@
         <guava.version>31.1-jre</guava.version>
         <guice.version>7.0.0</guice.version>
         <hk2.version>2.6.1</hk2.version>
-        <jackson-databind.version>2.13.4.2</jackson-databind.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson-annotation.version>2.21</jackson-annotation.version>
+        <jackson-databind.version>2.21.2</jackson-databind.version>
+        <jackson.version>2.21.2</jackson.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <!--
@@ -270,7 +271,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-annotation.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,11 +126,11 @@
         -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
-        <jakarta.ws.rs-api.version>3.0.0</jakarta.ws.rs-api.version>
+        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <jaxb-api.version>4.0.5</jaxb-api.version>
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>
         <jersey-client.version>${jersey.version}</jersey-client.version>
-        <jersey.version>3.0.18</jersey.version>
+        <jersey.version>3.1.11</jersey.version>
         <jetty.version>11.0.26</jetty.version>
         <jjwt.version>0.11.5</jjwt.version>
         <joda-time.version>2.12.7</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1643,7 +1643,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.7.2.1</version>
+                    <version>4.9.8.3</version>
                     <configuration>
                         <skip>${check.skip-spotbugs}</skip>
                         <jvmArgs>-Xmx${build.jvmsize}</jvmArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         "jakarta servlet 5 vs 6 vs 6.1 is there any breaking changes from 5 to 6.x"
         -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
-        <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
+        <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
         <jakarta.ws.rs-api.version>3.0.0</jakarta.ws.rs-api.version>
         <jaxb-api.version>4.0.5</jaxb-api.version>
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>

--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
         <killbill-api.version>0.55.0-6402be0-SNAPSHOT</killbill-api.version>
         <killbill-base-plugin.version>5.2.0-a5c0ade-SNAPSHOT</killbill-base-plugin.version>
         <killbill-client.version>1.3.11</killbill-client.version>
-        <killbill-commons.version>0.27.0-3209360-SNAPSHOT</killbill-commons.version>
-        <killbill-platform.version>0.42.0-cc150c5-SNAPSHOT</killbill-platform.version>
+        <killbill-commons.version>0.27.0-95cf901-SNAPSHOT</killbill-commons.version>
+        <killbill-platform.version>0.42.0-2d0476e-SNAPSHOT</killbill-platform.version>
         <killbill-plugin-api.version>0.28.0-b8017ea-SNAPSHOT</killbill-plugin-api.version>
         <killbill-testing-mysql.version>1.0.2</killbill-testing-mysql.version>
         <logback.version>1.5.32</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -309,18 +309,18 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-base</artifactId>
+                <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+                <artifactId>jackson-jakarta-rs-base</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+                <artifactId>jackson-jakarta-rs-json-provider</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
+                <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <killbill-plugin-api.version>0.28.0-b8017ea-SNAPSHOT</killbill-plugin-api.version>
         <killbill-testing-mysql.version>1.0.2</killbill-testing-mysql.version>
         <logback.version>1.5.32</logback.version>
-        <metrics.version>4.2.12</metrics.version>
+        <metrics.version>4.2.38</metrics.version>
         <netty.version>4.1.84.Final</netty.version>
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
         <osgi.activator>$${classes;EXTENDS;org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase}</osgi.activator>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
         <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
         <jaxb-api.version>4.0.5</jaxb-api.version>
+        <jaxb-runtime.version>4.0.7</jaxb-runtime.version>
         <jersey-client.version>${jersey.version}</jersey-client.version>
         <jersey.version>2.39.1</jersey.version>
         <jetty.version>10.0.16</jetty.version>
@@ -813,14 +814,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>2.3.6</version>
-                <exclusions>
-                    <exclusion>
-                        <!-- We use jakarta.activation:jakarta.activation-api instead -->
-                        <groupId>com.sun.activation</groupId>
-                        <artifactId>jakarta.activation</artifactId>
-                    </exclusion>
-                </exclusions>
+                <version>${jaxb-runtime.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         "jakarta servlet 5 vs 6 vs 6.1 is there any breaking changes from 5 to 6.x"
         -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
-        <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
+        <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
         <jaxb-api.version>4.0.5</jaxb-api.version>
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <jaxb-api.version>4.0.5</jaxb-api.version>
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>
         <jersey-client.version>${jersey.version}</jersey-client.version>
-        <jersey.version>2.39.1</jersey.version>
+        <jersey.version>3.0.18</jersey.version>
         <jetty.version>10.0.16</jetty.version>
         <jjwt.version>0.11.5</jjwt.version>
         <joda-time.version>2.12.5</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <ehcache.version>3.9.10</ehcache.version>
         <embedded-postgres.version>2.0.4</embedded-postgres.version>
         <guava.version>31.1-jre</guava.version>
-        <guice.version>5.1.0</guice.version>
+        <guice.version>7.0.0</guice.version>
         <hk2.version>2.6.1</hk2.version>
         <jackson-databind.version>2.13.4.2</jackson-databind.version>
         <jackson.version>2.13.4</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>
         <jersey-client.version>${jersey.version}</jersey-client.version>
         <jersey.version>3.0.18</jersey.version>
-        <jetty.version>10.0.16</jetty.version>
+        <jetty.version>11.0.26</jetty.version>
         <jjwt.version>0.11.5</jjwt.version>
         <joda-time.version>2.12.5</joda-time.version>
         <!-- We cannot upgrade to 3.16.x, yet. See

--- a/pom.xml
+++ b/pom.xml
@@ -707,6 +707,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <!-- required by Jooby in killbill-commons -->
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-deploy</artifactId>
                 <version>${jetty.version}</version>
@@ -777,6 +783,18 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-xml</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <!-- required by Jooby in killbill-commons -->
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <!-- required by Jooby in killbill-commons -->
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-jetty-api</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <osgi.transitive-dependency>true</osgi.transitive-dependency>
         <osgi.version>8.0.0</osgi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.targetJdk>11</project.build.targetJdk>
+        <project.build.targetJdk>21</project.build.targetJdk>
         <release.auto-version-submodules>true</release.auto-version-submodules>
         <release.preparation-goals>clean verify</release.preparation-goals>
         <release.push-changes>true</release.push-changes>

--- a/pom.xml
+++ b/pom.xml
@@ -130,12 +130,12 @@
              https://github.com/killbill/killbill-oss-parent/issues/557
              https://github.com/killbill/killbill-oss-parent/pull/411 -->
         <jooq.version>3.15.12</jooq.version>
-        <killbill-api.version>0.54.0</killbill-api.version>
-        <killbill-base-plugin.version>5.1.10</killbill-base-plugin.version>
+        <killbill-api.version>0.55.0-370fa77-SNAPSHOT</killbill-api.version>
+        <killbill-base-plugin.version>5.2.0-a5c0ade-SNAPSHOT</killbill-base-plugin.version>
         <killbill-client.version>1.3.11</killbill-client.version>
-        <killbill-commons.version>0.27.0-c115581-SNAPSHOT</killbill-commons.version>
-        <killbill-platform.version>0.41.19</killbill-platform.version>
-        <killbill-plugin-api.version>0.27.3</killbill-plugin-api.version>
+        <killbill-commons.version>0.27.0</killbill-commons.version>
+        <killbill-platform.version>0.42.0-35b289e-SNAPSHOT</killbill-platform.version>
+        <killbill-plugin-api.version>0.28.0-b8017ea-SNAPSHOT</killbill-plugin-api.version>
         <killbill-testing-mysql.version>1.0.2</killbill-testing-mysql.version>
         <logback.version>1.3.14</logback.version>
         <metrics.version>4.2.12</metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,16 +109,16 @@
         <compiler.fail-warnings>false</compiler.fail-warnings>
         <deploy.deploy-at-end>true</deploy.deploy-at-end>
         <derby.version>10.15.2.0</derby.version>
-        <ehcache.version>3.9.10</ehcache.version>
+        <ehcache.version>3.11.1</ehcache.version>
         <embedded-postgres.version>2.0.4</embedded-postgres.version>
         <guava.version>31.1-jre</guava.version>
         <guice.version>7.0.0</guice.version>
-        <hk2.version>2.6.1</hk2.version>
+        <hk2.version>3.0.6</hk2.version>
         <jackson-annotation.version>2.21</jackson-annotation.version>
         <jackson-databind.version>2.21.2</jackson-databind.version>
         <jackson.version>2.21.2</jackson.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
-        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <!--
         Tempted to update directly to 6.x, but the answer of prompt below hold me back:
@@ -126,14 +126,14 @@
         -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
+        <jakarta.ws.rs-api.version>3.0.0</jakarta.ws.rs-api.version>
         <jaxb-api.version>4.0.5</jaxb-api.version>
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>
         <jersey-client.version>${jersey.version}</jersey-client.version>
         <jersey.version>3.0.18</jersey.version>
         <jetty.version>11.0.26</jetty.version>
         <jjwt.version>0.11.5</jjwt.version>
-        <joda-time.version>2.12.5</joda-time.version>
+        <joda-time.version>2.12.7</joda-time.version>
         <!-- We cannot upgrade to 3.16.x, yet. See
              https://github.com/killbill/killbill-oss-parent/issues/557
              https://github.com/killbill/killbill-oss-parent/pull/411 -->
@@ -147,7 +147,7 @@
         <killbill-testing-mysql.version>1.0.2</killbill-testing-mysql.version>
         <logback.version>1.5.32</logback.version>
         <metrics.version>4.2.38</metrics.version>
-        <netty.version>4.1.84.Final</netty.version>
+        <netty.version>4.2.7.Final</netty.version>
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
         <osgi.activator>$${classes;EXTENDS;org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase}</osgi.activator>
         <osgi.annotation.version>8.1.0</osgi.annotation.version>
@@ -236,9 +236,9 @@
         <repository.snapshot.id>central</repository.snapshot.id>
         <repository.snapshot.name>Central Snapshots Repository</repository.snapshot.name>
         <repository.snapshot.url>https://central.sonatype.com/repository/maven-snapshots/</repository.snapshot.url>
-        <shiro.version>1.12.0</shiro.version>
+        <shiro.version>2.0.6</shiro.version>
         <skipTests>false</skipTests>
-        <slf4j.version>2.0.9</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <surefireArgLine>-Xmx${build.jvmsize} --illegal-access=permit</surefireArgLine>
         <swagger.version>1.6.7</swagger.version>
     </properties>
@@ -625,8 +625,16 @@
                 <artifactId>org.apache.felix.log</artifactId>
                 <version>1.2.6</version>
             </dependency>
-            <!-- Because of https://issues.apache.org/jira/browse/SHIRO-679 (duplicate classes across artifacts),
-                 we cannot upgrade until 2.0.0 is released (https://github.com/apache/shiro/pull/236) -->
+            <dependency>
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-cache</artifactId>
+                <version>${shiro.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-config-core</artifactId>
+                <version>${shiro.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.shiro</groupId>
                 <artifactId>shiro-core</artifactId>
@@ -634,20 +642,30 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-crypto-core</artifactId>
+                <version>${shiro.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-crypto-hash</artifactId>
+                <version>${shiro.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shiro</groupId>
                 <artifactId>shiro-guice</artifactId>
                 <version>${shiro.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <!-- We use jakarta.annotation:jakarta.annotation-api instead -->
-                        <groupId>javax.annotation</groupId>
-                        <artifactId>javax.annotation-api</artifactId>
-                    </exclusion>
-                </exclusions>
+                <classifier>jakarta</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-lang</artifactId>
+                <version>${shiro.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.shiro</groupId>
                 <artifactId>shiro-web</artifactId>
                 <version>${shiro.version}</version>
+                <classifier>jakarta</classifier>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
@@ -724,6 +742,10 @@
                         <artifactId>jetty-servlet-api</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.eclipse.jetty.toolchain</groupId>
+                        <artifactId>jetty-jakarta-servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <!-- https://github.com/eclipse/jetty.project/issues/5943 -->
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
@@ -761,6 +783,17 @@
                 <groupId>org.ehcache</groupId>
                 <artifactId>ehcache</artifactId>
                 <version>${ehcache.version}</version>
+                <classifier>jakarta</classifier>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.ehcache</groupId>
@@ -909,7 +942,7 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.29.2-GA</version>
+                <version>3.30.2-GA</version>
             </dependency>
             <dependency>
                 <groupId>org.joda</groupId>
@@ -1393,7 +1426,7 @@
             <dependency>
                 <groupId>org.kill-bill.commons</groupId>
                 <artifactId>killbill-jooby</artifactId>
-                <version>0.26.14-SNAPSHOT</version>
+                <version>${killbill-commons.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.kill-bill.commons</groupId>
@@ -1574,7 +1607,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>2.0</version>
+                <version>2.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -1873,7 +1906,7 @@
                                     <include>junit:junit:[4.11,)</include>
                                 </includes>
                             </bannedDependencies>
-                            <banDuplicatePomDependencyVersions />
+                            <banDuplicatePomDependencyVersions/>
                             <requireUpperBoundDeps>
                                 <excludes>
                                     <!-- Wildcards don't seem to work -->
@@ -2118,8 +2151,8 @@
                                 <skip>${check.skip-rat}</skip>
                                 <ignoreErrors>${check.ignore-rat}</ignoreErrors>
                                 <licenseFamilies>
-                                    <licenseFamily implementation="org.apache.rat.license.Apache20LicenseFamily" />
-                                    <licenseFamily implementation="org.apache.rat.license.MITLicenseFamily" />
+                                    <licenseFamily implementation="org.apache.rat.license.Apache20LicenseFamily"/>
+                                    <licenseFamily implementation="org.apache.rat.license.MITLicenseFamily"/>
                                 </licenseFamilies>
                                 <useDefaultExcludes>true</useDefaultExcludes>
                                 <parseSCMIgnoresAsExcludes>true</parseSCMIgnoresAsExcludes>
@@ -2244,6 +2277,14 @@
                             <dependency>
                                 <groupId>org.apache.shiro</groupId>
                                 <artifactId>shiro-crypto-event</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.ehcache</groupId>
+                                <artifactId>ehcache</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.ehcache</groupId>
+                                <artifactId>ehcache-clustered</artifactId>
                             </dependency>
                         </ignoredDependencies>
                         <ignoredResourcePatterns combine.children="append">

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <hk2.version>2.6.1</hk2.version>
         <jackson-databind.version>2.13.4.2</jackson-databind.version>
         <jackson.version>2.13.4</jackson.version>
+        <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
@@ -507,7 +508,7 @@
             <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
-                <version>1.2.2</version>
+                <version>${jakarta.activation-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,11 @@
         <jackson.version>2.13.4</jackson.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
-        <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
+        <!--
+        Tempted to update directly to 6.x, but the answer of prompt below hold me back:
+        "jakarta servlet 5 vs 6 vs 6.1 is there any breaking changes from 5 to 6.x"
+        -->
+        <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
         <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
         <jaxb-api.version>4.0.5</jaxb-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
         <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
-        <jaxb-api.version>2.3.3</jaxb-api.version>
+        <jaxb-api.version>4.0.5</jaxb-api.version>
         <jersey-client.version>${jersey.version}</jersey-client.version>
         <jersey.version>2.39.1</jersey.version>
         <jetty.version>10.0.16</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <check.skip-enforcer>false</check.skip-enforcer>
         <check.skip-rat>false</check.skip-rat>
         <check.skip-spotbugs>false</check.skip-spotbugs>
-        <check.spotbugs-exclude-filter-file />
+        <check.spotbugs-exclude-filter-file/>
         <compiler.fail-warnings>false</compiler.fail-warnings>
         <deploy.deploy-at-end>true</deploy.deploy-at-end>
         <derby.version>10.15.2.0</derby.version>
@@ -141,8 +141,8 @@
         <killbill-api.version>0.55.0-6402be0-SNAPSHOT</killbill-api.version>
         <killbill-base-plugin.version>5.2.0-a5c0ade-SNAPSHOT</killbill-base-plugin.version>
         <killbill-client.version>1.3.11</killbill-client.version>
-        <killbill-commons.version>0.27.0</killbill-commons.version>
-        <killbill-platform.version>0.42.0-35b289e-SNAPSHOT</killbill-platform.version>
+        <killbill-commons.version>0.27.0-3209360-SNAPSHOT</killbill-commons.version>
+        <killbill-platform.version>0.42.0-cc150c5-SNAPSHOT</killbill-platform.version>
         <killbill-plugin-api.version>0.28.0-b8017ea-SNAPSHOT</killbill-plugin-api.version>
         <killbill-testing-mysql.version>1.0.2</killbill-testing-mysql.version>
         <logback.version>1.5.32</logback.version>
@@ -153,8 +153,8 @@
         <osgi.annotation.version>8.1.0</osgi.annotation.version>
         <osgi.dependency>*;scope=compile|runtime;inline=true</osgi.dependency>
         <osgi.description>${project.description}</osgi.description>
-        <osgi.export />
-        <osgi.extra-import />
+        <osgi.export/>
+        <osgi.extra-import/>
         <osgi.fixupmessages>"Classes found in the wrong directory...","Unused Import-Package instructions...","While traversing the type tree for...";is:=ignore</osgi.fixupmessages>
         <osgi.import>
             ${osgi.extra-import},
@@ -218,7 +218,7 @@
         </osgi.import>
         <osgi.name>${project.name}</osgi.name>
         <osgi.noclassforname>true</osgi.noclassforname>
-        <osgi.private />
+        <osgi.private/>
         <osgi.symbolic-name>${project.groupId}.${project.artifactId}</osgi.symbolic-name>
         <osgi.transitive-dependency>true</osgi.transitive-dependency>
         <osgi.version>8.0.0</osgi.version>


### PR DESCRIPTION
Update various version to support `killbill:0.26.x-SNAPSHOT release`.