### PR TITLE
update killbill-client.version to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <jooq.version>3.15.12</jooq.version>
         <killbill-api.version>0.54.0</killbill-api.version>
         <killbill-base-plugin.version>5.1.12</killbill-base-plugin.version>
-        <killbill-client.version>1.3.14</killbill-client.version>
+        <killbill-client.version>1.4.0</killbill-client.version>
         <killbill-commons.version>0.26.15</killbill-commons.version>
         <killbill-platform.version>0.41.21</killbill-platform.version>
         <killbill-plugin-api.version>0.27.3</killbill-plugin-api.version>


### PR DESCRIPTION
Because "auto release oss-parent" fails: https://github.com/killbill/killbill-client-java/actions/runs/25946244203
But artifact already exist: https://repo1.maven.org/maven2/org/kill-bill/billing/killbill-client-java/1.4.0/