### PR TITLE
temporarily changes various Kill Bill dependencies to release version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,12 +139,12 @@
              https://github.com/killbill/killbill-oss-parent/issues/557
              https://github.com/killbill/killbill-oss-parent/pull/411 -->
         <jooq.version>3.15.12</jooq.version>
-        <killbill-api.version>0.55.0-f25d74b-SNAPSHOT</killbill-api.version>
-        <killbill-base-plugin.version>5.2.0-b98ff57-SNAPSHOT</killbill-base-plugin.version>
-        <killbill-client.version>1.4.1-a285cee-SNAPSHOT</killbill-client.version>
-        <killbill-commons.version>0.27.1-1f25dad-SNAPSHOT</killbill-commons.version>
-        <killbill-platform.version>0.42.0-a10b98f-SNAPSHOT</killbill-platform.version>
-        <killbill-plugin-api.version>0.28.0-b8017ea-SNAPSHOT</killbill-plugin-api.version>
+        <killbill-api.version>0.54.0</killbill-api.version>
+        <killbill-base-plugin.version>5.1.12</killbill-base-plugin.version>
+        <killbill-client.version>1.4.0</killbill-client.version>
+        <killbill-commons.version>0.26.15</killbill-commons.version>
+        <killbill-platform.version>0.41.21</killbill-platform.version>
+        <killbill-plugin-api.version>0.27.3</killbill-plugin-api.version>
         <killbill-testing-mysql.version>1.0.2</killbill-testing-mysql.version>
         <logback.version>1.5.32</logback.version>
         <metrics.version>4.2.38</metrics.version>


### PR DESCRIPTION
Needed because maven central refuse to release artifact where dependencies rely on snapshot version. 

See: https://github.com/killbill/killbill-oss-parent/actions/runs/27581553643/job/81542740164