### PR TITLE
update central-publishing-maven-plugin to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2348,7 +2348,7 @@
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.7.0</version>
+                    <version>0.11.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <autoPublish>true</autoPublish>


### PR DESCRIPTION
Needed to to avoid release problem.Sonatype's Central API added a new "warnings" field to its response, and plugin version 0.7.0 doesn't know how to deserialize it.