### PR TITLE
update central-publishing-maven-plugin to 0.11.0 to avoid release problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2320,7 +2320,7 @@
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.7.0</version>
+                    <version>0.11.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <autoPublish>true</autoPublish>


### PR DESCRIPTION
Sonatype's Central API added a new "warnings" field to its response, and plugin version 0.7.0 doesn't know how to deserialize it Jackson blows up.

Do the same thing like master's b47bef49fa2998a5c671a4f4641f2573f89613c7