### PR TITLE
Update redisson version and remove netty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,6 @@
         <killbill-testing-mysql.version>1.0.2</killbill-testing-mysql.version>
         <logback.version>1.5.38</logback.version>
         <metrics.version>4.2.38</metrics.version>
-        <netty.version>4.2.7.Final</netty.version>
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
         <osgi.activator>$${classes;EXTENDS;org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase}</osgi.activator>
         <osgi.annotation.version>8.1.0</osgi.annotation.version>
@@ -446,11 +445,6 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-jackson</artifactId>
                 <version>${jjwt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-buffer</artifactId>
-                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -496,10 +496,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- use heavily by killbill-commons (jdbi/skife/config) -->
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.14.5</version>
+                <version>1.17.7</version>
             </dependency>
             <dependency>
                 <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1485,9 +1485,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <!-- conflict between mockito-core and redisson. mockito (at the time of writing) insist on using 3.3
+                on their main branch. -->
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
-                <version>3.3</version>
+                <version>3.4</version>
             </dependency>
             <dependency>
                 <!-- Conflict between mariadb-java-client and osgi-over-slf4j -->
@@ -1528,7 +1530,8 @@
             <dependency>
                 <groupId>org.redisson</groupId>
                 <artifactId>redisson</artifactId>
-                <version>3.17.7</version>
+                <!-- This is the only version that not causing problem with various jackson deps -->
+                <version>3.50.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,6 @@
         <guava.version>33.6.0-jre</guava.version>
         <guice.version>7.0.0</guice.version>
         <hk2.version>3.0.6</hk2.version>
-        <jackson-annotation.version>2.21</jackson-annotation.version>
-        <jackson-databind.version>2.21.2</jackson-databind.version>
         <jackson.version>2.21.2</jackson.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
@@ -270,64 +268,11 @@
                 <version>1.5.1</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson-annotation.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-csv</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-smile</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-joda</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
-                <artifactId>jackson-jakarta-rs-base</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
-                <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.util</groupId>
-                <artifactId>low-gc-membuffers</artifactId>
-                <version>1.2.0</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
In this PR, CIs are expected to fails, because `killbill-commons`, `killbill-platform` and `killbill` still have dependency to netty.