### PR TITLE
make redisson scope provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1478,6 +1478,7 @@
                 <artifactId>redisson</artifactId>
                 <!-- This is the only version that not causing problem with various jackson deps -->
                 <version>3.50.0</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
as an alternative to [this PR](https://github.com/killbill/killbill-oss-parent/pull/1000), I think make `redisson` as `provided` dependency is better.