### PR TITLE
update to jackson 2.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <guava.version>33.6.0-jre</guava.version>
         <guice.version>7.0.0</guice.version>
         <hk2.version>3.0.6</hk2.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>


### PR DESCRIPTION
Do not automatically merge if green because CI's ref-killbill point to non-master branch: 2cdda79e2c07b7b39b6897dcb1855ac7b83ede56

---

Update, commit clean. `ref-killbill` reverted back to master.